### PR TITLE
Promote Rebecca

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
                                         <li>Frances Berriman<br><span class="title">Senior Designer</span></li>
                                         <li>Jenny Montoya Tansey<br><span class="title">Safety & Justice Lead</span></li> 
                                         <li>
-                                            Rebecca Coelius<br><span class="title">Health Lead</span>
+                                            Rebecca Coelius<br><span class="title">Health Director</span>
                                             <ul>
                                                 <li>Jake Solomon<br><span class="title">Health Product Manager</span></li>
                                                 <li>Dave Guarino<br><span class="title">Health Engineer</span></li>


### PR DESCRIPTION
@RebeccaCoelius joined us last May as health vertical lead. In her half year here at CfA, she’s cleared a space for new, exciting, direct work with food stamps and social services and led the team of @lippytak, @daguar, and @alanjosephwilliams on a mission to create experimental alternatives to difficult and abusive interactions with government. In 2015, we’re working to expand these activities to the two newer focus areas, Safety & Justice and Economic Development.

In recognition of health team’s incredible output, and her critical help getting the other focus areas off to a great start, Rebecca’s being promoted from Health Lead to Health Director.