### PR TITLE
Deleted old staff

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,9 +103,7 @@
                                                 <li>Debs Schrimmer<br><span class="title">Research &amp; Editorial Coordinator</span></li>
                                             </ul>
                                         </li>
-                                        <li>John Leonard<br><span class="title">Senior Manager, Gov Programs</span></li>
                                         <li>Lynn Fine<br><span class="title">Code for All Content Manager</span></li>
-                                        <li>David Rowe <br><span class="title">Content Manager</span></li>
                                         <li>Dharmishta Rood<br><span class="title">Companies Manager</span></li>
                                     </ul>
                                 </li>


### PR DESCRIPTION
Removed David Rowe & John Leonard from org chart. 

@davidrleonard - Please review
@meghanreilly  @danhon - I made these changes for you

